### PR TITLE
Minor updates.

### DIFF
--- a/mdistiller/distillers/_common.py
+++ b/mdistiller/distillers/_common.py
@@ -70,7 +70,7 @@ def make_zscore_mask(data: torch.Tensor, threshold: float=5.5, adaptive: bool=Tr
 @torch.no_grad()
 def make_gaussian_std_mask(x: torch.Tensor, threshold: float=2.0, eps: float=1.0E-8, except_cls: bool=True):
     '''
-    :input:
+    :params:
         data: batch, spatial, channel
         
     :returns:

--- a/mdistiller/engine/cfg.py
+++ b/mdistiller/engine/cfg.py
@@ -81,7 +81,7 @@ CFG.LOG.WANDB = False
 """Artifact Manipulating Distillation"""
 CFG.AMD = CN()
 CFG.AMD.M_LAYERS = [5]  # manipulating layers
-CFG.AMD.ALIGN_TYPE = 'cosine'  # 'cosine', 'mse', 'both'
+CFG.AMD.ALIGN_TYPE = 'mse'  # 'cosine', 'mse', 'both'
 CFG.AMD.INPUT_SIZE = [224, 224]
 CFG.AMD.AF = CN()
 CFG.AMD.AF.ENABLE = True

--- a/tools/lineval/test/nyud.py
+++ b/tools/lineval/test/nyud.py
@@ -75,7 +75,7 @@ def main(args: Namespace):
     head_state_dict = load_head_checkpoint(
         args.expname, tag=args.tag, 
         when=args.lineval_when, dataset='nyud',
-        lineval_tag='best'
+        lineval_tag=args.lineval_tag
     )['head']
     head_state_dict = {
         key.replace('module.', ''): val
@@ -117,6 +117,7 @@ if __name__ == '__main__':
     init_parser(parser, defaults=dict(batch_size=16))
     parser.add_argument('--temperature', '-T', type=float, default=0.03)
     parser.add_argument('--lineval-when', '-lw', type=str, default=None)
+    parser.add_argument('--lineval-tag', '-lt', type=str, default='best')
     args = parser.parse_args()
     
     try:

--- a/tools/lineval/utils.py
+++ b/tools/lineval/utils.py
@@ -71,7 +71,7 @@ def load_head_checkpoint(
     when: str|None=None,
     lineval_tag: Literal['last', 'best']|int='last',
 ):
-    filename = os.path.join('output', exp_name, 'lineval', tag)
+    filename = os.path.join('output', exp_name, 'lineval', str(tag))
     if when is None:
         dirname = sorted(filter(lambda x: x.startswith(f'{dataset}_'), os.listdir(filename)))[-1]
         filename = os.path.join(filename, dirname)


### PR DESCRIPTION
Minor updates:
- Comment in `mdistiller/distillers/_common.py`.
- Default configuration value of `AMD.ALIGN_TYPE`.
- Loading models from checkpoint (`tools/lineval/utils.py`).
- Linear probing evaluation tag as an lineval argument.

On branch dev-minor-updates
Changes to be committed:
	modified:   mdistiller/distillers/_common.py
	modified:   mdistiller/engine/cfg.py
	modified:   tools/lineval/test/nyud.py
	modified:   tools/lineval/utils.py