### PR TITLE
Enabled training and testing the dpt decoder.

### DIFF
--- a/tools/dpteval/dpt/blocks.py
+++ b/tools/dpteval/dpt/blocks.py
@@ -5,9 +5,11 @@ from .vit import (
     _make_pretrained_vitb_rn50_384,
     _make_pretrained_vitl16_384,
     _make_pretrained_vitb16_384,
+    _make_vit_b16_backbone,
     forward_vit,
 )
 
+from tools.lineval.utils import load_from_checkpoint, get_config
 
 def _make_encoder(
     backbone,
@@ -60,6 +62,46 @@ def _make_encoder(
     else:
         print(f"Backbone '{backbone}' not implemented")
         assert False
+
+    return pretrained, scratch
+    
+    
+def _make_encoder_from_chekcpoint(
+    checkpoint,
+    features,
+    groups=1,
+    expand=False,
+    exportable=True,
+    hooks=None,
+    use_vit_only=False,
+    use_readout="ignore",
+    enable_attention_hooks=False,
+):
+    model, result = load_from_checkpoint(checkpoint, tag='latest')
+    cfg, _  = get_config(checkpoint, 'latest')
+    
+    if 'tiny' in cfg.DISTILLER.STUDENT:
+        vit_features = 192
+    elif 'small' in cfg.DISTILLER.STUDENT:
+        vit_features = 384
+    elif 'base' in cfg.DISTILLER.STUDENT:
+        vit_features = 768
+    else:
+        raise ValueError(f"Unsupported student model: {cfg.DISTILLER.STUDENT}")
+    
+    res_features = [vit_features // 8, vit_features // 4, vit_features // 2 , vit_features]
+    pretrained = _make_vit_b16_backbone(
+        model, 
+        features = res_features,
+        size = cfg.AMD.INPUT_SIZE,
+        hooks = [2, 5, 8, 11],
+        vit_features = vit_features,
+        use_readout=use_readout,
+        enable_attention_hooks=enable_attention_hooks,
+    )
+    scratch = _make_scratch(
+        res_features, features, groups=groups, expand=expand
+    )
 
     return pretrained, scratch
 

--- a/tools/dpteval/dpt/models.py
+++ b/tools/dpteval/dpt/models.py
@@ -8,6 +8,7 @@ from .blocks import (
     FeatureFusionBlock_custom,
     Interpolate,
     _make_encoder,
+    _make_encoder_from_chekcpoint,
     forward_vit,
 )
 
@@ -27,6 +28,7 @@ class DPT(BaseModel):
     def __init__(
         self,
         head,
+        checkpoint=None,
         features=256,
         backbone="vitb_rn50_384",
         readout="project",
@@ -44,19 +46,30 @@ class DPT(BaseModel):
             "vitb16_384": [2, 5, 8, 11],
             "vitl16_384": [5, 11, 17, 23],
         }
-
-        # Instantiate backbone and reassemble blocks
-        self.pretrained, self.scratch = _make_encoder(
-            backbone,
-            features,
-            False,  # Set to true of you want to train from scratch, uses ImageNet weights
-            groups=1,
-            expand=False,
-            exportable=False,
-            hooks=hooks[backbone],
-            use_readout=readout,
-            enable_attention_hooks=enable_attention_hooks,
-        )
+        if checkpoint is not None: # for load our student
+            self.pretrained, self.scratch = _make_encoder_from_chekcpoint(
+                checkpoint,
+                features,
+                groups=1,
+                expand=False,
+                exportable=False,
+                hooks=[2, 5, 8, 11],
+                use_readout=readout,
+                enable_attention_hooks=enable_attention_hooks,
+            )
+        else:
+            # Instantiate backbone and reassemble blocks
+            self.pretrained, self.scratch = _make_encoder(
+                backbone,
+                features,
+                False,  # Set to true of you want to train from scratch, uses ImageNet weights
+                groups=1,
+                expand=False,
+                exportable=False,
+                hooks=hooks[backbone],
+                use_readout=readout,
+                enable_attention_hooks=enable_attention_hooks,
+            )
 
         self.scratch.refinenet1 = _make_fusion_block(features, use_bn)
         self.scratch.refinenet2 = _make_fusion_block(features, use_bn)
@@ -84,7 +97,21 @@ class DPT(BaseModel):
         out = self.scratch.output_conv(path_1)
 
         return out
-
+    
+    def get_decoder_named_parameters(self):
+        decoder_prefixes = [
+            "scratch.",
+            "pretrained.act_postprocess1.",
+            "pretrained.act_postprocess2.",
+            "pretrained.act_postprocess3.",
+            "pretrained.act_postprocess4.",
+        ]
+        return [
+            (name, param)
+            for name, param in self.named_parameters()
+            if any(name.startswith(prefix) for prefix in decoder_prefixes)
+        ]
+    
 
 class DPTDepthModel(DPT):
     def __init__(

--- a/tools/dpteval/nyud.py
+++ b/tools/dpteval/nyud.py
@@ -1,0 +1,173 @@
+import os
+from argparse import ArgumentParser, Namespace
+from tqdm.auto import tqdm
+import numpy as np
+
+import einops
+from typing import Literal
+from datetime import datetime
+import torch
+from torch import nn, optim
+import torch.nn.functional as F
+from torch import distributed as dist
+
+from mdistiller.dataset.nyud_v2 import get_nyud_dataloaders
+from mdistiller.utils import dist_fn
+
+from tools.lineval.utils import init_parser
+from tools.lineval.nyud import crop_resize
+
+from tools.dpteval.dpt.models import DPTDepthModel
+from tools.dpteval.utils import prepare_dir
+
+
+def main(args: Namespace):
+    rank = int(os.environ['LOCAL_RANK'])
+    IS_MASTER = bool(int(os.environ['IS_MASTER_NODE']))
+    DEVICE = rank
+    EPOCHS = args.epochs
+    
+    if IS_MASTER:
+        _, log_filename, best_filename, last_filename = prepare_dir(
+            args.expname, 
+            tag='latest', 
+            dataset='nyud', 
+            args=vars(args)
+        )
+    
+    # DataLoaders, Models
+    train_loader, test_loader, _ = get_nyud_dataloaders(
+        args.batch_size//world_size, args.test_batch_size//world_size,
+        args.num_workers, use_ddp=True,
+    )
+    
+    model = DPTDepthModel(
+        checkpoint=args.expname,
+        non_negative=True,
+        enable_attention_hooks=False,
+    )
+    model.train()
+    model = model.cuda(DEVICE)
+    model = nn.parallel.DistributedDataParallel(model, device_ids=[rank], find_unused_parameters=True)
+
+    learnable_params = model.module.get_decoder_named_parameters()
+    param_names, learnable_params = [*zip(*learnable_params)]
+    
+    optimizer = optim.Adam(
+        learnable_params, 
+        lr=args.learning_rate,
+    ) # learning rate of 1e-4 is used in dpt.
+
+    # Training Loop
+    best_rmse = torch.inf
+    train_loss_list, train_rmse_list, test_loss_list, test_rmse_list = [], [], [], []
+    for epoch in range(args.epochs):
+        with tqdm(train_loader, desc=f'TRAIN {epoch+1}', dynamic_ncols=True, disable=not IS_MASTER) as bar:
+            total_loss, total_rmse, total = 0, 0, 0
+            for bidx, (input, target) in enumerate(bar):
+                input, target = crop_resize(input, target, size=224, random_crop=True)
+                pred = model(input.cuda(DEVICE))
+
+                loss = F.mse_loss(pred, target.to(DEVICE))
+                loss.backward()
+                optimizer.step()
+                optimizer.zero_grad()
+
+                with torch.no_grad():
+                    target_depth = 0.5 + target * 9.5  # for real depth from normalized target min 0.5m max 10m
+                    pred_depth = 0.5 + pred * 9.5
+                    
+                    loss = F.mse_loss(pred, target.to(DEVICE), reduction='none')
+
+                    loss_all = dist_fn.gather(loss)
+                    local_rmse = torch.square(pred_depth - target_depth.to(DEVICE)).flatten(1).mean(dim=1).sqrt()
+                    rmse_all = dist_fn.gather(local_rmse)
+                    
+                    total_loss += loss_all.mean().cpu().item()
+                    total_rmse += rmse_all.sum().cpu().item()
+                    total += loss_all.size(0)
+                    
+                    if IS_MASTER:
+                        bar.set_postfix(dict(
+                            lr=optimizer.param_groups[0]['lr'],
+                            loss=total_loss/total,
+                            rmse=total_rmse/total,
+                        ))
+            train_rmse = total_rmse / total
+            train_loss = total_loss / total
+
+        with tqdm(test_loader, desc=f' TEST {epoch+1}', dynamic_ncols=True, disable=not IS_MASTER) as bar, torch.no_grad():
+            total_loss, total_rmse, total = 0, 0, 0
+            for input, target in bar:
+                input, target = crop_resize(input, target, size=224, random_crop=False)
+                pred = model(input.cuda(DEVICE))
+                pred = pred.squeeze(1)
+
+                loss = F.mse_loss(pred, target.to(DEVICE), reduction='none')
+                
+                loss_all = dist_fn.gather(loss)
+                target_depth = 0.5 + target * 9.5
+                pred_depth = 0.5 + pred * 9.5
+                local_rmse = torch.square(pred_depth - target_depth.to(DEVICE)).flatten(1).mean(dim=1).sqrt()
+                rmse_all = dist_fn.gather(local_rmse)
+                
+                total_loss += loss_all.mean().cpu().item()
+                total_rmse += rmse_all.sum().cpu().item()
+                total += loss_all.size(0)
+                
+                if IS_MASTER:
+                    bar.set_postfix(dict(
+                        loss=total_loss/total,
+                        rmse=total_rmse/total,
+                    ))
+            test_rmse = total_rmse / total
+            test_loss = total_loss / total
+        
+        # Logging
+        train_loss_list.append(train_loss)
+        train_rmse_list.append(train_rmse)
+        test_loss_list.append(test_loss)
+        test_rmse_list.append(test_rmse)
+        
+        if IS_MASTER:
+            with open(log_filename, 'a') as file:
+                print(f'- epoch: {epoch+1}', file=file)
+                print(f'  train_loss: {train_loss:.4f}', file=file)
+                print(f'  train_rmse: {train_rmse:.4f}', file=file)
+                print(f'  test_loss: {test_loss:.4f}', file=file)
+                print(f'  test_rmse: {test_rmse:.4f}', file=file)
+                print(file=file)
+
+            ckpt = dict(
+                epoch=epoch+1,
+                train_loss=train_loss_list,
+                train_rmse=train_rmse_list,
+                test_loss=test_loss_list,
+                test_rmse=test_rmse_list,
+                decoder_state_dict={
+                    name: param.clone().detach().cpu()
+                    for name, param in zip(param_names, learnable_params)
+                }
+            )
+            if test_rmse < best_rmse:
+                best_rmse = test_rmse
+                torch.save(ckpt, str(best_filename))
+            torch.save(ckpt, str(last_filename))
+
+if __name__ == '__main__':
+    parser = ArgumentParser('dpteval.nyud')
+    init_parser(parser, defaults=dict(epochs=1000))
+    args = parser.parse_args()
+    
+    rank = int(os.environ['LOCAL_RANK'])
+    world_size = int(os.environ['WORLD_SIZE'])
+    os.environ['IS_MASTER_NODE'] = str(int(rank == 0))
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    torch.cuda.set_device(rank)
+    
+    try:
+        main(args)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        dist.destroy_process_group()

--- a/tools/dpteval/test/nyud.py
+++ b/tools/dpteval/test/nyud.py
@@ -1,0 +1,112 @@
+import os
+from argparse import ArgumentParser, Namespace
+from tqdm.auto import tqdm
+
+import torch
+import torch.nn.functional as F
+
+from mdistiller.dataset.nyud_v2 import get_nyud_dataloaders
+
+from tools.lineval.utils import init_parser
+from tools.lineval.nyud import crop_resize
+
+from tools.dpteval.dpt.models import DPTDepthModel
+from tools.dpteval.utils import load_head_checkpoint
+
+def compute_depth_metrics(pred, gt, mask=None, max_depth=10.0, eps=1.0E-8):
+    """
+    pred, gt: torch.Tensor of shape (B, H, W), in meters
+    mask: optional torch.BoolTensor of shape (B, H, W)
+    Returns: dict with average metrics over batch
+    """
+    pred = pred.float()
+    gt = gt.float()
+
+    if mask is None:
+        mask = (gt > 0) & (gt < max_depth) & (pred > 0) & (pred < max_depth)
+    pred_valid = pred[mask]
+    gt_valid = gt[mask]
+
+    rmse = torch.sqrt(torch.mean((pred_valid - gt_valid) ** 2))
+    mae = torch.mean(torch.abs(pred_valid - gt_valid))
+    rel = torch.mean(torch.abs(pred_valid - gt_valid) / (gt_valid + eps))
+
+    ratio = torch.maximum(pred_valid / (gt_valid + eps), gt_valid / (pred_valid + eps))
+    delta1 = torch.mean((ratio < 1.25 ** 1).float())
+    delta2 = torch.mean((ratio < 1.25 ** 2).float())
+    delta3 = torch.mean((ratio < 1.25 ** 3).float())
+
+    return {
+        'RMSE': rmse.item(),
+        'MAE': mae.item(),
+        'REL': rel.item(),
+        'δ<1.25': delta1.item(),
+        'δ<1.25^2': delta2.item(),
+        'δ<1.25^3': delta3.item(),
+    }
+
+
+def main(args: Namespace):
+    DEVICE = args.device
+    
+    # DataLoaders, Models
+    _, test_loader, _ = get_nyud_dataloaders(
+        1, args.batch_size,
+        args.num_workers, use_ddp=False,
+    )
+
+    model = DPTDepthModel(
+        checkpoint=args.expname,
+        non_negative=True,
+        enable_attention_hooks=False,
+    )
+    model = model.cuda(DEVICE)
+    
+    decoder_state_dict = load_head_checkpoint(
+        args.expname, tag=args.tag, 
+        when=args.dpteval_when, dataset='nyud',
+        eval_tag=args.dpteval_tag
+    )['decoder_state_dict']
+    
+    print(model.load_state_dict(decoder_state_dict, strict=False))
+    
+    # Test Loop
+    with tqdm(test_loader, desc=f' TEST', dynamic_ncols=True) as bar, torch.no_grad():
+        total_loss, preds_all, targets_all = 0, [], []
+        for input, target in bar:
+            input, target = crop_resize(input, target, size=224, random_crop=False)
+            pred = model(input.cuda(DEVICE)) # (B, 1, H, W)
+            pred = pred.squeeze(1)
+            
+            batch_size = input.size(0)
+            loss = torch.nn.functional.cross_entropy(pred, target.to(DEVICE))
+            target_depth = 0.5 + target * 9.5
+            pred_depth = 0.5 + pred * 9.5
+            
+            total_loss += loss.cpu().item() * batch_size
+            preds_all.append(pred_depth.cpu())
+            targets_all.append(target_depth.cpu())
+        
+    preds = torch.cat(preds_all, dim=0)
+    targets = torch.cat(targets_all, dim=0)
+    mean_loss = total_loss / len(preds)
+    
+    metrics = compute_depth_metrics(preds, targets)
+    metrics['loss'] = mean_loss
+    max_key_len = max(map(len, metrics.keys()))
+    for key, val in metrics.items():
+        print(f'{key:<{max_key_len}}: {val:.4f}')
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser('dpteval.test.nyud')
+    init_parser(parser, defaults=dict(batch_size=16))
+    parser.add_argument('--temperature', '-T', type=float, default=0.03)
+    parser.add_argument('--dpteval-when', '-dw', type=str, default=None)
+    parser.add_argument('--dpteval-tag', '-dt', type=str, default='best')
+    args = parser.parse_args()
+    
+    try:
+        main(args)
+    except KeyboardInterrupt:
+        pass

--- a/tools/dpteval/utils.py
+++ b/tools/dpteval/utils.py
@@ -1,0 +1,45 @@
+import os
+import torch
+from pathlib import Path
+from typing import Literal
+from datetime import datetime
+
+def prepare_dir(
+    exp_name: str,
+    dir_name: str = 'dpteval',
+    tag: Literal['latest', 'best']|int='latest',
+    dataset: str='imagenet',
+    args: dict|None=None,
+):
+    lineval_dir = Path('output').joinpath(exp_name, dir_name)
+    nowstr = datetime.now().strftime('_%y%m%d_%H%M%S')
+    log_dir = lineval_dir.joinpath(str(tag), dataset + nowstr)
+    log_dir.mkdir(parents=True)
+    
+    if args is not None:
+        cfg_filename = log_dir.joinpath('_cfg.yaml')
+        with open(cfg_filename, 'w') as file:
+            for key, val in args.items():
+                print(f'{key}: {val}', file=file)
+    
+    log_filename = log_dir.joinpath('log.yaml')
+    best_filename = log_dir.joinpath('best.pt')
+    last_filename = log_dir.joinpath('last.pt')
+    return log_dir, log_filename, best_filename, last_filename
+
+def load_head_checkpoint(
+    exp_name: str,
+    dir_name: str = 'dpteval',
+    tag: Literal['latest', 'best']|int='latest',
+    dataset: Literal['imagenet', 'nyud', 'ade20k']='nyud',
+    when: str|None=None,
+    eval_tag: Literal['last', 'best']|int='last',
+):
+    filename = os.path.join('output', exp_name, dir_name, str(tag))
+    if when is None:
+        dirname = sorted(filter(lambda x: x.startswith(f'{dataset}_'), os.listdir(filename)))[-1]
+        filename = os.path.join(filename, dirname)
+    else:
+        filename = os.path.join(filename, f'{dataset}_{when}')
+    filename = os.path.join(filename, f'{eval_tag}.pt')
+    return torch.load(filename, weights_only=False, map_location='cpu')


### PR DESCRIPTION
- Modified `dpt/blocks.py `and `dpt/models.py` for loading pre-trained student checkpoint and config file.
- Add `nyud.py` and `test/nyud.py` for training and testing the depth estimation with the DPT decoder.
- Additional `utils.py` (Almost the same as `lineval/utils.py`)

On branch dev-dpteval-amd
Changes to be committed:
	modified:   tools/dpteval/dpt/blocks.py
	modified:   tools/dpteval/dpt/models.py
	new file:   tools/dpteval/nyud.py
	new file:   tools/dpteval/test/nyud.py
	new file:   tools/dpteval/utils.py